### PR TITLE
Utilización de Bootstrap v3.3.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "dependencies": {
     "angular": "^1.3.0",
-    "bootstrap": "^3.2.0",
+    "bootstrap": "=3.3.4",
     "angular-animate": "^1.3.0",
     "angular-cookies": "^1.3.0",
     "angular-resource": "^1.3.0",


### PR DESCRIPTION
Debido a un error en **Grunt** **[1]**, el uso de una versión de Bootstrap posterior a ```3.3.4``` produce que ```grunt serve``` no incluya las hojas de estilo de Bootstrap en la aplicación. Por esto, se especifica la instalación de Bootstrap ```3.3.4``` en el archivo ```bower.json```.

**[1]** https://github.com/yeoman/generator-angular/issues/1116