### PR TITLE
Especificación de dependencias para la ejecución

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "saludweb",
   "version": "0.0.0",
-  "dependencies": {},
+  "dependencies": {
+    "express": "^4.13.3",
+    "gzippo": "^0.2.0",
+    "morgan": "^1.6.1"
+  },
   "repository": {},
   "devDependencies": {
     "express": "^4.12.4",


### PR DESCRIPTION
Se especifican como ```dependencies``` (no ```devDependencies```) los paquetes necesarios para **ejecutar** la aplicación. Este cambio tiene por objetivo solucionar el error existente en *Heroku*, y que la interfaz se despliegue correctamente.

Los paquetes especificados son los utilizados por el script ```web.js```.