### PR TITLE
Se ve siempre encima la barra de navegación de la página

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -35,6 +35,7 @@ body {
 .nav-header{
   background-image: url(/images/head.png);
   font-size:1.2em;
+  z-index: 999;
 }
 /*Redefinición de los colores de los botones del nav*/
 .navbar-default .navbar-nav > .active > a,


### PR DESCRIPTION
Se refiere a que la barra verde en la que están los links arriba de la página se ve siempre cuando scrolleas!.. anteriormente se le superponian cosas