### PR TITLE
Corrección de error en compilador Slug, por Font-Awesome

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,3 +1,4 @@
 /test
 /app/styles/font-awesome-4.4.0/less
 /app/styles/font-awesome-4.4.0/scss
+/app/styles/font-awesome-4.4.0/css/font-awesome.css

--- a/app/index.html
+++ b/app/index.html
@@ -16,7 +16,7 @@
     <!-- endbuild -->
     <!-- build:css(.tmp) styles/main.css -->
     <link rel="stylesheet" href="styles/main.css">
-    <link rel="stylesheet" href="styles/font-awesome-4.4.0/css/font-awesome.css">
+    <link rel="stylesheet" href="styles/font-awesome-4.4.0/css/font-awesome.min.css">
     <!-- endbuild -->
   </head>
   <body ng-app="saludWebApp">


### PR DESCRIPTION
Se hace uso de la versión **minificada** de *Font-Awesome*, y se añade al ```slugignore``` la versión completa del CSS. De esta manera, se trata de evitar el error producido por **Heroku**, al alcanzar el tiempo máximo de compilación debido a la ejecución de ```htmlmin```.