### PR TITLE
Utilización de 'ng-required' para campo input

### DIFF
--- a/app/scripts/controllers/analysis-new.js
+++ b/app/scripts/controllers/analysis-new.js
@@ -48,7 +48,7 @@ angular.module('saludWebApp')
           aFileModal.$promise.then(aFileModal.show);
           // It creates a new AnalysisFile object
           var af = new AnalysisFile();
-          af.required = 'required';
+          af.required = true;
           create_analysisFile(af);
     };
 
@@ -61,7 +61,7 @@ angular.module('saludWebApp')
     $scope.editAdjunto = function($index,a){
           aFileModal.$promise.then(aFileModal.show);
           var af = $scope.adjuntos[$index];
-          af.required = '';
+          af.required = false;
           create_analysisFile($scope.adjuntos[$index],function(){
             aFileModal.$promise.then(aFileModal.hide());
             });

--- a/app/views/partials/analysis-addAttachment.html
+++ b/app/views/partials/analysis-addAttachment.html
@@ -12,7 +12,7 @@
 
             <div class="form-group">
                 <div class="col-sm-10">
-                  <input id='file' type="file"  files-model="aFile.image_file" {{aFile.required}} >
+                  <input id='file' type="file"  files-model="aFile.image_file" ng-required="{{aFile.required}}" >
                 </div>
             </div>
             <div class="thumbnail"  onclick="$('#file').click();" >


### PR DESCRIPTION
Se corrige la forma de indicar que un campo ```input``` es obligatorio mediante valores de variables. Esto corrige, además, el error generado en **Heroku**, donde la compilación se trababa en el proceso ```htmlmin```, debido a problemas en archivos HTML.