### PR TITLE
Corrección en URL de recurso 'Profile'

### DIFF
--- a/app/scripts/services/resources/profile.js
+++ b/app/scripts/services/resources/profile.js
@@ -11,19 +11,19 @@ angular.module('saludWebApp')
   .factory('Profile', function (global, $resource) {
 
     // URL of specific API resource
-    var url = global.getApiUrl() + '/my/profile';
+    var url = global.getApiUrl() + '/profiles/:id';
 
-    return $resource( 
-        url,{ 
+    return $resource(
+        url,{
             id: '@_id'
             },{
             update: {
-                method: 'PUT' 
+                method: 'PUT'
                 },
             query: {
                 method: 'GET',
                 isArray: false
                 }
             }
-        );  
+        );
     });


### PR DESCRIPTION
Se corrige el URL del **recurso Profile**, que apuntaba incorrectamente a ```/my/profile``` en vez de a ```/profiles/<id>```.