### PR TITLE
Reemplazo de ocurrencia de imágenes en JS con usemin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -234,12 +234,18 @@ module.exports = function (grunt) {
     usemin: {
       html: ['<%= yeoman.dist %>/{,*/}*.html'],
       css: ['<%= yeoman.dist %>/styles/{,*/}*.css'],
+      js: ['<%= yeoman.dist %>/scripts/{,*/}*.js'],
       options: {
         assetsDirs: [
           '<%= yeoman.dist %>',
           '<%= yeoman.dist %>/images',
           '<%= yeoman.dist %>/styles'
-        ]
+        ],
+        patterns: {
+          js: [
+            [/(images\/.*?\.(?:gif|jpeg|jpg|png|webp|svg))/gm, 'Update the JS to reference our revved images']
+          ]
+        },
       }
     },
 

--- a/app/scripts/controllers/analyses.js
+++ b/app/scripts/controllers/analyses.js
@@ -10,7 +10,7 @@
 angular.module('saludWebApp')
   .controller('AnalysesCtrl', function (
       $scope,
-      $location , 
+      $location ,
       Auth,
       MyAnalyses,
       Analysis,
@@ -28,12 +28,12 @@ angular.module('saludWebApp')
 
         var q_af = Analysis.get({id:a.id,element:'files'},function(){
           $.each(q_af.resource,function(i,af){
-                a.af_id = af.id 
+                a.af_id = af.id
             });
           if ( a.af_id ){
             a.imageSrc = (global.getApiUrl()+'/analysis_files/'+a.af_id+'/download');
           }else{
-            a.imageSrc = 'images/escul.jpeg';
+            a.imageSrc = '/images/escul.jpeg';
           }
           });
 


### PR DESCRIPTION
Se añaden los patrones necesarios para que el proceso ```usemin``` de *Grunt* reemplace las ocurrencias de rutas a imágenes por las correctas **[1]**, ya que el nombre de las mismas es modificado por *Grunt*.

**[1]** https://stackoverflow.com/questions/23919027/how-to-let-grunt-usemin-update-the-js-to-reference-our-revved-images