### PR TITLE
Reemplazo de 'Save' por 'Guardar' en formularios

### DIFF
--- a/app/views/partials/analysis-addAttachment.html
+++ b/app/views/partials/analysis-addAttachment.html
@@ -58,7 +58,7 @@
 
             <div class="form-group">
                 <div class="col-sm-offset-2 col-sm-10">
-                    <input type="submit" class="btn btn-success" value="Save" ng-disabled="measurementForm.$invalid">
+                    <input type="submit" class="btn btn-success" value="Guardar" ng-disabled="measurementForm.$invalid">
                 </div>
             </div>
 

--- a/app/views/partials/analysisform.html
+++ b/app/views/partials/analysisform.html
@@ -107,6 +107,6 @@
 
 <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
-        <input type="submit" class="btn btn-success" value="Save" ng-disabled="analysisForm.$invalid">
+        <input type="submit" class="btn btn-success" value="Guardar" ng-disabled="analysisForm.$invalid">
     </div>
 </div>

--- a/app/views/partials/config.html
+++ b/app/views/partials/config.html
@@ -24,7 +24,7 @@
 
               <div class="form-group">
                 <div class="col-sm-10">
-                  <input type="submit" class="btn btn-success" value="Save" ng-disabled="measurementForm.$invalid">
+                  <input type="submit" class="btn btn-success" value="Guardar" ng-disabled="measurementForm.$invalid">
                 </div>
               </div>
         </form>

--- a/app/views/partials/groupform.html
+++ b/app/views/partials/groupform.html
@@ -49,6 +49,6 @@
 
 <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
-        <input type="submit" class="btn btn-success" value="Save" ng-disabled="groupForm.$invalid">
+        <input type="submit" class="btn btn-success" value="Guardar" ng-disabled="groupForm.$invalid">
     </div>
 </div>

--- a/app/views/partials/measurementform.html
+++ b/app/views/partials/measurementform.html
@@ -67,6 +67,6 @@
 </div>
 <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
-        <input type="submit" class="btn btn-success" value="Save" ng-disabled="measurementForm.$invalid">
+        <input type="submit" class="btn btn-success" value="Guardar" ng-disabled="measurementForm.$invalid">
     </div>
 </div>

--- a/app/views/partials/memberform.html
+++ b/app/views/partials/memberform.html
@@ -46,7 +46,7 @@
 
             <div class="form-group">
                 <div class="col-sm-offset-2 col-sm-10">
-                    <input type="submit" class="btn btn-success" value="Save" ng-disabled="memberForm.$invalid">
+                    <input type="submit" class="btn btn-success" value="Guardar" ng-disabled="memberForm.$invalid">
                 </div>
             </div>
 

--- a/app/views/partials/profileform.html
+++ b/app/views/partials/profileform.html
@@ -87,7 +87,7 @@
 
 <div class = "form-group">
     <div class = "col-sm-offset-2 col-sm-10">
-        <input type = "submit" class = "btn btn-success" value = "Save" ng-disabled = "profileForm.$invalid"/>
+        <input type = "submit" class = "btn btn-success" value="Guardar" ng-disabled = "profileForm.$invalid"/>
         <a class = "btn btn-default" href = "javascript:history.go(-1)"> Cancelar </a>
     </div>
 </div>


### PR DESCRIPTION
Se reemplazó el texto de los botones *Save* por **Guardar**, en los formularios.

Fixes #91