### PR TITLE
Inclusión de archivos HTML en 'views/' para Grunt usemin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -232,7 +232,10 @@ module.exports = function (grunt) {
 
     // Performs rewrites based on filerev and the useminPrepare configuration
     usemin: {
-      html: ['<%= yeoman.dist %>/{,*/}*.html'],
+      html: [
+        '<%= yeoman.dist %>/{,*/}*.html',
+        '<%= yeoman.dist %>/views/{,*/}*.html'
+      ],
       css: ['<%= yeoman.dist %>/styles/{,*/}*.css'],
       js: ['<%= yeoman.dist %>/scripts/{,*/}*.js'],
       options: {


### PR DESCRIPTION
Se incluye el directorio ```views``` y sus subdirectorios, para que sean **procesados por ```usemin```**, y reemplazar así las rutas a las imágenes cuando se ejecuta ```grunt serve:dist```.

Esto corrige el **error existente en #94**, que no muestra el logo de YesDoc en el navbar de la versión mobile, al ejecutar ```grunt serve:dist```. Esto se debe a que la ruta a la imagen se especifica en un **archivo HTML ubicado en ```views/partials```**.

**Recursos utilizados**:
**[1]** https://stackoverflow.com/questions/20859450/gruntjs-usemin-doesnt-look-in-subfolders