### PR TITLE
cambio de color del alert

### DIFF
--- a/app/styles/light-bootstrap-dashboard.css
+++ b/app/styles/light-bootstrap-dashboard.css
@@ -982,7 +982,7 @@ body > .navbar-collapse[data-color="green"]:after {
   background-color: #1F77D0;
 }
 .alert-success {
-  background-color: #5CB85C;
+  background-color: #a1e82c;
 }
 .alert-warning {
   background-color: #ffbc67;

--- a/app/styles/light-bootstrap-dashboard.css
+++ b/app/styles/light-bootstrap-dashboard.css
@@ -913,7 +913,7 @@ body > .navbar-collapse[data-color="green"]:after {
 .input-group-focus .input-group-addon {
   border-color: #9A9A9A;
 }
-
+/*
 .alert {
   border: 0;
   border-radius: 0;
@@ -991,7 +991,7 @@ body > .navbar-collapse[data-color="green"]:after {
 .alert-danger {
   background-color: #D9534F;
 }
-
+*/
 .table .radio,
 .table .checkbox {
   position: relative;

--- a/app/styles/light-bootstrap-dashboard.css
+++ b/app/styles/light-bootstrap-dashboard.css
@@ -913,7 +913,6 @@ body > .navbar-collapse[data-color="green"]:after {
 .input-group-focus .input-group-addon {
   border-color: #9A9A9A;
 }
-
 .alert {
   border: 0;
   border-radius: 0;
@@ -977,14 +976,13 @@ body > .navbar-collapse[data-color="green"]:after {
   padding-left: 65px;
 }
 
+
 .alert-info {
   background-color: #63d8f1;
 }
-
 .alert-success {
-  background-color: #a1e82c;
+  background-color: #5CB85C;
 }
-
 .alert-warning {
   background-color: #ffbc67;
 }

--- a/app/styles/light-bootstrap-dashboard.css
+++ b/app/styles/light-bootstrap-dashboard.css
@@ -913,6 +913,7 @@ body > .navbar-collapse[data-color="green"]:after {
 .input-group-focus .input-group-addon {
   border-color: #9A9A9A;
 }
+/*
 .alert {
   border: 0;
   border-radius: 0;
@@ -990,7 +991,7 @@ body > .navbar-collapse[data-color="green"]:after {
 .alert-danger {
   background-color: #fc727a;
 }
-
+*/
 .table .radio,
 .table .checkbox {
   position: relative;

--- a/app/styles/light-bootstrap-dashboard.css
+++ b/app/styles/light-bootstrap-dashboard.css
@@ -913,7 +913,7 @@ body > .navbar-collapse[data-color="green"]:after {
 .input-group-focus .input-group-addon {
   border-color: #9A9A9A;
 }
-/*
+
 .alert {
   border: 0;
   border-radius: 0;
@@ -979,7 +979,7 @@ body > .navbar-collapse[data-color="green"]:after {
 
 
 .alert-info {
-  background-color: #63d8f1;
+  background-color: #1F77D0;
 }
 .alert-success {
   background-color: #5CB85C;
@@ -989,9 +989,9 @@ body > .navbar-collapse[data-color="green"]:after {
 }
 
 .alert-danger {
-  background-color: #fc727a;
+  background-color: #D9534F;
 }
-*/
+
 .table .radio,
 .table .checkbox {
   position: relative;

--- a/app/views/partials/analysis-addMeasurement.html
+++ b/app/views/partials/analysis-addMeasurement.html
@@ -7,7 +7,7 @@
         <h4 class="modal-title"> Medición </h4>
       </div>
       <div class='well' style='margin-bottom: 0px;'>
-        <div ng-bind-html="msg"></div>
+          <div ng-bind-html="msg"></div>
         <form name="measurementForm" class="form-horizontal" role="form" ng-submit="submitMeasurement()">
             <div ng-include="'views/partials/measurementform.html'"></div>
         </form>


### PR DESCRIPTION
Bootstrap utiliza un color muy claro en sus carteles de alerta, los cuales no se van a ver en la presentación, puedo mantenerlos o utilizar un verde fuerte como el utilizado en la botonera vertical "#5CB85C".
Recomendación dada en el issue #109 
![alert](https://cloud.githubusercontent.com/assets/3909570/11121260/926d143e-8933-11e5-9d3f-9b5eb9b3c30d.png)
