### PR TITLE
Copia de fuentes de Flexslider en Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -366,6 +366,11 @@ module.exports = function (grunt) {
           dest: '<%= yeoman.dist %>'
         }, {
           expand: true,
+          cwd: 'bower_components/flexslider',
+          src: 'fonts/*',
+          dest: '<%= yeoman.dist %>/styles'
+        }, {
+          expand: true,
           cwd: 'bower_components/font-awesome',
           src: 'fonts/*',
           dest: '<%= yeoman.dist %>'


### PR DESCRIPTION
Se agregan las **fuentes de Flexslider** al directorio ```dist```, para que funcionen correctamente mediante ```grunt serve:dist```. Debido a que **Flexslider usa rutas relativas** para acceder a sus fuentes, las mismas se agregan al directorio ```dist/styles/fonts```.

Fix #132