### PR TITLE
Mensajes de confirmación al eliminar.

### DIFF
--- a/app/scripts/controllers/analysis-new.js
+++ b/app/scripts/controllers/analysis-new.js
@@ -57,7 +57,7 @@ angular.module('saludWebApp')
           $scope.confirm = {};
           $scope.confirm.class = 'danger';
           $scope.confirm.message =
-              'Esta seguro que desea eliminar el archivo adjunto <b>'
+              '¿Está seguro que desea eliminar el archivo adjunto <b>'
               +a.description+'</b> ?';
 
           $scope.confirm.confirm = function(){
@@ -218,8 +218,8 @@ angular.module('saludWebApp')
           $scope.confirm = {};
           $scope.confirm.class = 'danger';
           $scope.confirm.message =
-              'Esta seguro que desea eliminar la medición <b>'
-              +m.tipo.nombre+' '+ m.value+' '+ m.unidad.nombre+' </b> ?';
+              '¿Está seguro que desea eliminar la medición <b>'
+              +m.tipo.nombre+': '+ m.value+' ('+ m.unidad.nombre+') </b> ?';
 
           $scope.confirm.confirm = function(){
               $scope.mediciones.splice($index, 1);

--- a/app/scripts/controllers/analysis-new.js
+++ b/app/scripts/controllers/analysis-new.js
@@ -54,8 +54,30 @@ angular.module('saludWebApp')
 
       /* Delete Analysis File object */
       $scope.deleteAdjunto = function($index,a){
-          $scope.adjuntos.splice($index, 1);
-        }
+          $scope.confirm = {};
+          $scope.confirm.class = 'danger';
+          $scope.confirm.message =
+              'Esta seguro que desea eliminar el archivo adjunto <b>'
+              +a.description+'</b> ?';
+
+          $scope.confirm.confirm = function(){
+
+              $scope.adjuntos.splice($index, 1);
+              confirmDeleteModal.$promise.then(confirmDeleteModal.hide);
+
+          }
+
+          var confirmDeleteModal = $modal({ 
+            scope: $scope,
+            templateUrl: "views/partials/confirm.html", 
+            contentTemplate: false, 
+            html: true, 
+            show: false });
+
+          confirmDeleteModal.$promise.then(confirmDeleteModal.show);
+
+
+        };
 
       /* Edit Analysis File object */
       $scope.editAdjunto = function($index,a){
@@ -193,8 +215,28 @@ angular.module('saludWebApp')
 
       /* Delete Analyisis Measurement Modal */
       $scope.deleteMedicion = function ($index, m) {
-          $scope.mediciones.splice($index, 1);
+          $scope.confirm = {};
+          $scope.confirm.class = 'danger';
+          $scope.confirm.message =
+              'Esta seguro que desea eliminar la medición <b>'
+              +m.tipo.nombre+' '+ m.value+' '+ m.unidad.nombre+' </b> ?';
+
+          $scope.confirm.confirm = function(){
+              $scope.mediciones.splice($index, 1);
+              confirmDeleteModal.$promise.then(confirmDeleteModal.hide);
+          }
+
+          var confirmDeleteModal = $modal({ 
+            scope: $scope,
+            templateUrl: "views/partials/confirm.html", 
+            contentTemplate: false, 
+            html: true, 
+            show: false });
+
+          confirmDeleteModal.$promise.then(confirmDeleteModal.show);
+
           };
+
 
       /* Edit Analyisis Measurement Modal */
       $scope.editMedicion = function($index,a){

--- a/app/scripts/controllers/profileinformation.js
+++ b/app/scripts/controllers/profileinformation.js
@@ -158,7 +158,7 @@ angular.module('saludWebApp')
         $scope.deleteGroup = function($index){
           $scope.confirm = {};
           $scope.confirm.class = 'danger';
-          $scope.confirm.message = 'Esta seguro que desea eliminar el grupo <b>'+ $scope.groups[$index].name + '</b> ?';
+          $scope.confirm.message = '¿Está seguro que desea eliminar el grupo <b>'+ $scope.groups[$index].name + '</b> ?';
 
           $scope.confirm.confirm = function(){
             Groups.remove({id: $scope.groups[$index].id},function(response){

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -244,7 +244,6 @@ margin:4px;
 .caption-blue h3{
   overflow: hidden;
   height: 2.6em; 
-  line-height: 2.6em; 
   font-size: 1.4em; 
   margin:0px;
   vertical-align:middle
@@ -252,8 +251,8 @@ margin:4px;
 
 .caption-blue h3 span{
   display: inline-block;
+  line-height: 1.3em; 
   vertical-align: middle;
-  line-height: normal;
 }
 
 .caption-date{

--- a/app/views/partials/analysisform.html
+++ b/app/views/partials/analysisform.html
@@ -50,9 +50,9 @@
               <td><i class='fa fa-{{a.file_type}}'></i></td>
               <td>{{a.description}}</td>
               <td style='width:206px'>
-                <button type="button" ng-click="showImagen($index,m)" class="btn btn-primary"><span class='glyphicon glyphicon-eye-open'></span></button>
-                <button type="button" ng-click="editAdjunto($index,m)" class="btn btn-warning"><span class='glyphicon glyphicon-pencil'></span></button>
-                <button type="button" ng-click="deleteAdjunto($index, m)" class="btn btn-danger"><span class='glyphicon glyphicon-trash'></span></button>
+                <button type="button" ng-click="showImagen($index,a)" class="btn btn-primary"><span class='glyphicon glyphicon-eye-open'></span></button>
+                <button type="button" ng-click="editAdjunto($index,a)" class="btn btn-warning"><span class='glyphicon glyphicon-pencil'></span></button>
+                <button type="button" ng-click="deleteAdjunto($index, a)" class="btn btn-danger"><span class='glyphicon glyphicon-trash'></span></button>
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
Corrección de error de estilo para mejorar la lista de análisis, esta corrección sirve para que no se vea lo que no cabe del nombre del análisis en la vista previa del mismo. Se añadieron mensajes de confirmación para los eliminar sugerido en issue #84 .