### PR TITLE
Actualización de 'angular-flexslider' al estado de su rama master

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,13 +16,12 @@
     "d3": "~3.5.6",
     "angular-route-segment": "~1.5.0",
     "angular-motion": "~0.4.3",
-    "angular-flexslider": "~1.3.2",
     "angular-i18n": "~1.4.7",
     "font-awesome": "~4.4.0",
     "angular-moment": "~0.10.3",
-    "font-awesome": "~4.4.0",
     "nvd3": "~1.8.1",
-    "angularjs-slider": "~1.1.0"
+    "angularjs-slider": "~1.1.0",
+    "angular-flexslider": "master"
   },
   "devDependencies": {
     "angular-mocks": "^1.3.0"


### PR DESCRIPTION
Se configura **Bower**, para que instale la última versión de la rama ```master``` de **angular-flexslider**, y así poder comprobar si se resuelven algunos *issues* relacionados al uso de este paquete.