### PR TITLE
Cambio de formato de fecha en formularios

### DIFF
--- a/app/views/partials/analysis-addAttachment.html
+++ b/app/views/partials/analysis-addAttachment.html
@@ -27,7 +27,7 @@
                   <div class="form-group row">
                     <div class="col-md-6">
                       <input name="date" size="10" class="form-control" ng-model="aFile.datetime" data-autoclose="1" 
-                      data-timezone='UTC' placeholder="Fecha" bs-datepicker data-date-format="yyyy-MM-dd" type="text" required>
+                      data-timezone='UTC' placeholder="Fecha" bs-datepicker data-date-format="dd-MM-yyyy" type="text" required>
                     </div>
                     <div class="col-md-4">
                       <input name="time" size="4" class="form-control" ng-model="aFile.datetime" data-time-format="HH:mm:ss"

--- a/app/views/partials/analysisform.html
+++ b/app/views/partials/analysisform.html
@@ -6,7 +6,7 @@
       <div class="form-group row">
         <div class="col-md-6">
           <input name="date" size="10" class="form-control" ng-model="analysis.datetime" data-autoclose="1" 
-          data-timezone='UTC' placeholder="Fecha" bs-datepicker data-date-format="yyyy-MM-dd" type="text" required>
+          data-timezone='UTC' placeholder="Fecha" bs-datepicker data-date-format="dd-MM-yyyy" type="text" required>
         </div>
         <div class="col-md-4">
           <input name="time" size="4" class="form-control" ng-model="analysis.datetime" data-time-format="HH:mm:ss"

--- a/app/views/partials/measurementform.html
+++ b/app/views/partials/measurementform.html
@@ -70,7 +70,7 @@
       <div class="form-group row">
         <div class="col-md-6">
         <input name="date" size="10" class="form-control" ng-model="measurement.datetime" data-autoclose="1" 
-        data-timezone='UTC' placeholder="Date" bs-datepicker data-date-format="yyyy-MM-dd" type="text" required>
+        data-timezone='UTC' placeholder="Date" bs-datepicker data-date-format="dd-MM-yyyy" type="text" required>
         </div>
         <div class="col-md-4">
           <input name="time" size="4" class="form-control" ng-model="measurement.datetime" data-time-format="HH:mm:ss"


### PR DESCRIPTION
Se cambia el **formato de fecha**, en aquellos formularios que aún mostraban las fechas como ```yyyy-MM-dd```. El nuevo formato es ```dd-MM-yyyy```.