### PR TITLE
Una sola petición a token por necesidad de logueo

### DIFF
--- a/app/scripts/services/authentication.js
+++ b/app/scripts/services/authentication.js
@@ -157,15 +157,19 @@ angular.module('saludWebApp')
         isLogged: function(){
 
           // isLogged(onSuccessCallback)
-          if (arguments.length == 1) 
+          if (arguments.length == 1){ 
             isLogged(arguments[0]);
+            return;
+          }
 
           // isLogged(redirectURL,onSuccessCallback)
           if (arguments.length > 1){ 
             isLogged(arguments[1], arguments[0]);
+            return;
           }else{ 
           // isLogged(onSuccessCallback)
             isLogged(function(){});
+            return;
             }
           }
 


### PR DESCRIPTION
Cada vez que se evalua si el usuario está logueado, se evalua con el token contra la api, esto se realiza una sola vez. 
_Se mejoró ampliamente en el rendimiento_