### PR TITLE
Corrección en obtención de ID de MeasurementUnit

### DIFF
--- a/app/views/partials/measurementform.html
+++ b/app/views/partials/measurementform.html
@@ -16,7 +16,7 @@
     <label for="unit" class="col-sm-2 control-label">Unidad:</label>
     <div class="col-sm-10">
         <select name="unit" id="unit" class="form-control" 
-            ng-options="u.id as u.measurement_unit.name for u in unit" 
+            ng-options="u.measurement_unit.id as u.measurement_unit.name for u in unit" 
             ng-model="measurement.measurement_unit_id" 
             ng-disabled="measurementForm.type.$invalid" ng-change='getValidation()' required>
         </select>


### PR DESCRIPTION
Se corrige la obtención del ID de MeasurementUnit, en el formulario de mediciones, al navegar correctamente la relación entre la **validación** y la **unidad de medición**.